### PR TITLE
Improvement/#18961 service list without chef

### DIFF
--- a/resources/lib/service.rb
+++ b/resources/lib/service.rb
@@ -40,7 +40,7 @@ class ServiceListCmd < CmdParse::Command
     end
 
     unless File.exist?('/etc/redborder/services.json')
-      puts 'ERROR: Service list not found'
+      puts 'ERROR: Services list not found'
       return
     end
 

--- a/resources/lib/service.rb
+++ b/resources/lib/service.rb
@@ -66,19 +66,36 @@ class ServiceListCmd < CmdParse::Command
       if system("systemctl status #{systemd_service} &>/dev/null")
         ret = "running"
         running = running + 1
-        runtime = `systemctl status #{systemd_service} | grep 'Active:' | awk '{for(i=9;i<=NF;i++) printf $i " "; print ""}'`.strip
-
-        # Calculate the run time in seconds
-        total_seconds = 0
-        if runtime =~ /(\d+)min\s*(\d*)s*/
-          minutes = $1.to_i
-          seconds = $2.to_i
-          total_seconds = minutes * 60 + seconds
-        elsif runtime =~ /(\d+)s/
-          total_seconds = $1.to_i
-        end
 
         if $parser.data[:show_runtime]
+          runtime = `systemctl status #{systemd_service} | grep 'Active:' | awk '{for(i=9;i<=NF;i++) printf $i " "; print ""}'`.strip
+
+          # Calculate the run time in seconds
+          total_seconds = 0
+          if runtime =~ /(\d+)\s*year/
+            total_seconds += $1.to_i * 365 * 24 * 60 * 60
+          end
+
+          if runtime =~ /(\d+)\s*month/
+            total_seconds += $1.to_i * 30 * 24 * 60 * 60
+          end
+
+          if runtime =~ /(\d+)\s*day/
+            total_seconds += $1.to_i * 24 * 60 * 60
+          end
+
+          if runtime =~ /(\d+)\s*h/
+            total_seconds += $1.to_i * 60 * 60
+          end
+
+          if runtime =~ /(\d+)\s*min/
+            total_seconds += $1.to_i * 60
+          end
+
+          if runtime =~ /(\d+)\s*s/
+            total_seconds += $1.to_i
+          end
+
           if total_seconds < 60
             printf("%-33s #{green}%-33s#{reset}#{blink}%-10s#{reset}\n", "#{systemd_service}:", ret, runtime)
           else

--- a/resources/lib/service.rb
+++ b/resources/lib/service.rb
@@ -70,33 +70,8 @@ class ServiceListCmd < CmdParse::Command
         if $parser.data[:show_runtime]
           runtime = `systemctl status #{systemd_service} | grep 'Active:' | awk '{for(i=9;i<=NF;i++) printf $i " "; print ""}'`.strip
 
-          # Calculate the run time in seconds
-          total_seconds = 0
-          if runtime =~ /(\d+)\s*year/
-            total_seconds += $1.to_i * 365 * 24 * 60 * 60
-          end
-
-          if runtime =~ /(\d+)\s*month/
-            total_seconds += $1.to_i * 30 * 24 * 60 * 60
-          end
-
-          if runtime =~ /(\d+)\s*day/
-            total_seconds += $1.to_i * 24 * 60 * 60
-          end
-
-          if runtime =~ /(\d+)\s*h/
-            total_seconds += $1.to_i * 60 * 60
-          end
-
-          if runtime =~ /(\d+)\s*min/
-            total_seconds += $1.to_i * 60
-          end
-
-          if runtime =~ /(\d+)\s*s/
-            total_seconds += $1.to_i
-          end
-
-          if total_seconds < 60
+          # Blink when runtime is less than a minute
+          if runtime_info.match?(/^\d+\s*s/)
             printf("%-33s #{green}%-33s#{reset}#{blink}%-10s#{reset}\n", "#{systemd_service}:", ret, runtime)
           else
             printf("%-33s #{green}%-33s#{reset}%-10s\n", "#{systemd_service}:", ret, runtime)

--- a/resources/lib/service.rb
+++ b/resources/lib/service.rb
@@ -71,7 +71,7 @@ class ServiceListCmd < CmdParse::Command
           runtime = `systemctl status #{systemd_service} | grep 'Active:' | awk '{for(i=9;i<=NF;i++) printf $i " "; print ""}'`.strip
 
           # Blink when runtime is less than a minute
-          if runtime_info.match?(/^\d+\s*s/)
+          if runtime.match?(/^\d+\s*s/)
             printf("%-33s #{green}%-33s#{reset}#{blink}%-10s#{reset}\n", "#{systemd_service}:", ret, runtime)
           else
             printf("%-33s #{green}%-33s#{reset}%-10s\n", "#{systemd_service}:", ret, runtime)

--- a/resources/lib/service.rb
+++ b/resources/lib/service.rb
@@ -19,11 +19,11 @@ class ServiceListCmd < CmdParse::Command
   YELLOW = "\033[33m"
 
   def initialize
-    $parser.data[:show_runtime] = false
+    $parser.data[:show_runtime] = true
     $parser.data[:no_color] = false
     super('list', takes_commands: false)
     short_desc('List services from node')
-    options.on('-r', '--runtime', 'Show runtime') { $parser.data[:show_runtime] = true }
+    options.on('-q', '--quiet', 'Show list without runtime') { $parser.data[:show_runtime] = false }
     options.on('-n', '--no-color', 'Print without colors') { $parser.data[:no_color] = true }
   end
 


### PR DESCRIPTION
Improvements:
- Now show the runtime is enable by default (-q or --quiet to dont show it)
- rbli service list dont depend anymore of opscode-erchef running on the manager, its checking last know services enablement (write by chef in /etc/redborder/services.json)
- Services running less than one minute will blink in column runtime (usefull to detect failing services on a starting loop)

Related PRs:
- https://github.com/redBorder/cookbook-rb-manager/pull/223
- https://github.com/redBorder/redborder-cli/pull/32
- https://github.com/redBorder/cookbook-rb-ips/pull/52
- https://github.com/redBorder/cookbook-rb-proxy/pull/54