### PR TITLE
check for nil values

### DIFF
--- a/resources/lib/service.rb
+++ b/resources/lib/service.rb
@@ -199,7 +199,11 @@ class ServiceDisableCmd < CmdParse::Command
         n_node = utils.get_node(n)
         next unless n_node
         role = Chef::Role.load(n)
-        s3_role = role.override_attributes["redborder"]["services"]["s3"]
+        if role.override_attributes.dig('redborder','services','s3').nil?
+          s3_role = n_node['redborder']['services']['s3']
+        else
+          s3_role = role.override_attributes["redborder"]["services"]["s3"]
+        end
         total_enabled_nodes += 1 if s3_role
       end
 


### PR DESCRIPTION
The problem is that on the first ever execution upon installation, the hash redborder services s3 does not exist. This is fixed now with a check if the values are nil